### PR TITLE
Fix dirty buffer problem by clearing buffer before ReadDirectoryChangesW

### DIFF
--- a/Monitor.pas
+++ b/Monitor.pas
@@ -149,6 +149,7 @@ begin
     Events[1] := FShutdownHandle;
     while not Terminated do
     begin
+      FillChar(Buffer, BUFFER_SIZE, 0);
       if ReadDirectoryChangesW(FDirHandle, @Buffer[0], BUFFER_SIZE, FSubdirectories, GetNotifyMask, @BytesRead,
         @Overlap, nil) then
       begin


### PR DESCRIPTION
The buffer wasn't being cleared. Consequently, each file name was a conglomeration of the correct one being reported and previous ones, especially when a short named file was reported followed by one with a longer name; e.g "**wlc-ar-1.jpgge_20mb.jp**", when reporting a change to "**wlc-ar-1.jpg**" after reporting a change to "**SampleJPGImage_20mb.jpg**"